### PR TITLE
mice can no longer bump-open doors

### DIFF
--- a/maps/endeavor/endeavor_things.dm
+++ b/maps/endeavor/endeavor_things.dm
@@ -428,3 +428,8 @@
 	name = "xenomorph egg 100% chance"
 	spawn_nothing_percentage = 0
 	spawn_object = /obj/effect/alien/egg
+
+/obj/machinery/door/Bumped(atom/AM)
+	if(istype(AM, /mob/living/simple_mob/animal/passive/mouse))//Mice stay in maintenance unless let out.
+		return
+	. = ..()


### PR DESCRIPTION
stops the *entire* ship from being covered in mouse-dirt after a couple hours rather than just a few areas where mice walked through doors that were left open and such